### PR TITLE
feat: 부하 테스트용 Terraform base/test 2-스택 인프라 구성

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,78 @@
+# Cluverse 부하 테스트 인프라 (Terraform, base / test 2-스택)
+
+`apply`/`destroy`를 반복해도 DNS·HTTPS가 리셋되지 않도록 state를 두 개로 분리한다.
+
+| 스택 | 수명 | 내용 |
+|------|------|------|
+| `base/` | 한 번만 apply, destroy 안 함 | VPC/서브넷/IGW/라우팅(프라이빗 RT는 빈 채로), ALB+리스너+빈 TG, ACM 인증서, alb_sg, ECR |
+| `test/` | apply/destroy 반복 | NAT(+프라이빗 egress route), ECS on EC2, MySQL EC2, Redis EC2, Prometheus/Grafana EC2, Bastion, SG/IAM/SSM |
+
+- **base → test 참조**: `test/data.tf`의 `terraform_remote_state`(local backend, `../base/terraform.tfstate`). base를 S3 backend로 옮기면 이 설정도 함께 수정.
+- **네트워크 모드 합의**: ECS는 bridge + 동적 호스트 포트 → base의 target group은 `target_type = "instance"`. awsvpc로 바꾸려면 양쪽을 함께 바꿔야 한다 (`base/alb.tf` 주석).
+- ALB DNS 이름, ACM 검증 상태, ECR 이미지가 base에 있으므로 test를 아무리 destroy해도 유지된다.
+
+## 실행 순서 체크리스트
+
+1. **base apply**
+   ```bash
+   cd terraform/base
+   terraform init
+   terraform apply
+   ```
+2. **Spaceship에 ACM 검증 레코드 입력**
+   ```bash
+   terraform output acm_validation_records
+   ```
+   출력된 CNAME의 `name`에서 도메인 뒷부분을 뺀 호스트 부분을 Spaceship DNS Host에, `value`를 Value에 입력.
+3. **인증서 발급 확인 후 443 리스너 생성** (보통 수 분~30분)
+   ```bash
+   aws acm describe-certificate --certificate-arn $(terraform output -raw acm_certificate_arn) \
+     --query 'Certificate.Status'   # "ISSUED" 확인
+   terraform apply -var certificate_validated=true
+   ```
+4. **`api.cluverse.cona.team` CNAME → ALB DNS** (Spaceship)
+   ```bash
+   terraform output alb_dns_name
+   ```
+5. **이미지 ECR 푸시**
+   ```bash
+   aws ecr get-login-password --region ap-northeast-2 | \
+     docker login --username AWS --password-stdin $(terraform output -raw ecr_repository_url | cut -d/ -f1)
+   docker build -t $(terraform output -raw ecr_repository_url):latest .
+   docker push $(terraform output -raw ecr_repository_url):latest
+   ```
+6. **test apply**
+   ```bash
+   cd ../test
+   terraform init
+   terraform apply -var my_ip=$(curl -s ifconfig.me)/32 \
+     -var db_password='...8자이상...' \
+     -var ssh_public_key="$(cat ~/.ssh/id_ed25519.pub)"
+   ```
+7. **터널로 Grafana 연결**
+   ```bash
+   terraform output -raw ssh_tunnel_command   # 실행 후 http://localhost:3000 (admin/admin)
+   # 또는 SSH 없이: terraform output ssm_port_forward_examples
+   ```
+8. 이후에는 **test만 `apply`/`destroy` 반복**. DB/Redis는 EC2 직접 설치라 destroy 시 데이터가 휘발된다(매 테스트 클린 상태 — 의도된 동작).
+
+## 변수 (test)
+
+| 변수 | 필수 | 기본값 | 설명 |
+|------|------|--------|------|
+| `my_ip` | ✅ | - | Bastion SSH 허용 CIDR (예: `1.2.3.4/32`) |
+| `db_password` | ✅ | - | MySQL 비밀번호 (8자 이상, sensitive) |
+| `ssh_public_key` | | `""` | 비우면 키페어 없이 생성(SSM 접근만) |
+| `db_name` / `db_username` | | `cluverse_v2` / `cluverse_user` | application.yml과 일치 |
+| `ecs_desired_count` | | `1` | ECS 태스크 수 |
+| `ecs_instance_type` / `db_instance_type` / `redis_instance_type` / `monitoring_instance_type` | | `t3.small`/`t3.small`/`t3.micro`/`t3.small` | 인스턴스 타입 |
+| `container_image_tag` | | `latest` | ECR 이미지 태그 |
+
+## 설계 메모
+
+- **NAT를 test에 두는 이유**: 프라이빗 인스턴스가 user_data로 MySQL/Redis/Docker/exporter를 설치하므로 egress가 필요하지만, base에 두면 idle 시간에도 시간당 요금이 나간다. 대안으로 소프트웨어를 미리 구운 커스텀 AMI를 쓰면 NAT 없이 더 빠르고 싸다 — `test/nat.tf` 주석 참고.
+- **IAM 3역할 분리**: 컨테이너 인스턴스 역할 / task execution role / task role — `test/iam.tf` 주석 참고.
+- **헬스체크**: TG는 `/actuator/health`(matcher 200), ECS 서비스 grace period 180초(Spring Boot 부팅 대비).
+- **모니터링**: mysqld_exporter(9104)·redis_exporter(9121)는 고정 IP static scrape, node_exporter(9100)는 `tag:NodeExporter=true` EC2 SD로 자동 발견. 앱 `/actuator/prometheus`는 동적 포트라 제외 — 필요 시 `test/templates/monitoring.sh.tpl` 주석 참고.
+- **SG는 계단식 source SG 참조**: ALB→ECS(동적포트), ECS→DB(3306)/Redis(6379), monitoring→exporter 포트, bastion→22/터널 포트. 공인 IP 인바운드는 bastion 22(`my_ip`)와 ALB 80/443뿐.
+- 루트의 기존 `main.tf`/`variables.tf`는 구(단일 스택) 구성으로, 이 디렉터리와 무관하다.

--- a/terraform/base/acm.tf
+++ b/terraform/base/acm.tf
@@ -1,0 +1,14 @@
+# 도메인이 Route53이 아니라 Spaceship에 있으므로 aws_acm_certificate_validation을 쓰지 않는다.
+# (검증 레코드를 자동으로 만들 수 없어 apply가 무한 대기하게 됨)
+# 대신 domain_validation_options를 output(acm_validation_records)으로 뽑아
+# 사용자가 Spaceship DNS에 CNAME을 수동 입력한다. 발급 확인 후 certificate_validated=true로 재-apply.
+resource "aws_acm_certificate" "api" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = { Name = "cluverse-api-cert" }
+}

--- a/terraform/base/alb.tf
+++ b/terraform/base/alb.tf
@@ -1,0 +1,69 @@
+resource "aws_lb" "main" {
+  name               = "cluverse-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = aws_subnet.public[*].id
+
+  tags = { Name = "cluverse-alb" }
+}
+
+# 네트워크 모드 합의(base/test 공통 전제):
+#   test의 ECS는 bridge 모드 + 동적 호스트 포트(hostPort=0)를 쓴다.
+#   → target_type은 반드시 "instance" (awsvpc 모드였다면 "ip"여야 함).
+#   bridge+동적포트 선택 이유: t계열 인스턴스의 ENI 개수 제한 없이 인스턴스당 여러 태스크를
+#   올릴 수 있고, 부하 테스트에서 인스턴스 수보다 태스크 수를 유연하게 늘리기 좋다.
+#   트레이드오프: awsvpc는 태스크별 SG/IP가 생겨 관측이 깔끔하지만 ENI 제한으로 밀도가 낮다.
+resource "aws_lb_target_group" "api" {
+  name        = "cluverse-api-tg"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "instance"
+
+  # 부하 테스트 사이클을 빠르게 돌리기 위해 드레이닝을 짧게
+  deregistration_delay = 30
+
+  health_check {
+    path                = "/actuator/health"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = { Name = "cluverse-api-tg" }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+# 443 리스너는 인증서가 ISSUED 된 후에만 만들 수 있다 (variables.tf의 certificate_validated 참고).
+resource "aws_lb_listener" "https" {
+  count = var.certificate_validated ? 1 : 0
+
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate.api.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+}

--- a/terraform/base/ecr.tf
+++ b/terraform/base/ecr.tf
@@ -1,0 +1,25 @@
+# 이미지 저장소는 destroy 대상이 아니므로 base에 둔다 (test destroy 시에도 이미지 유지).
+resource "aws_ecr_repository" "api" {
+  name                 = "cluverse-api"
+  image_tag_mutability = "MUTABLE"
+
+  tags = { Name = "cluverse-api" }
+}
+
+# 부하 테스트용 이미지가 쌓이지 않도록 최근 10개만 유지
+resource "aws_ecr_lifecycle_policy" "api" {
+  repository = aws_ecr_repository.api.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "keep last 10 images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 10
+      }
+      action = { type = "expire" }
+    }]
+  })
+}

--- a/terraform/base/outputs.tf
+++ b/terraform/base/outputs.tf
@@ -1,0 +1,62 @@
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "퍼블릭 서브넷 ID 목록 (2 AZ)"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "프라이빗 서브넷 ID 목록 (2 AZ)"
+  value       = aws_subnet.private[*].id
+}
+
+output "private_subnet_cidrs" {
+  description = "프라이빗 서브넷 CIDR (test의 고정 private_ip가 이 대역 안이어야 함)"
+  value       = aws_subnet.private[*].cidr_block
+}
+
+output "private_route_table_id" {
+  description = "빈 프라이빗 라우팅 테이블 ID — test가 NAT egress route를 여기에 추가"
+  value       = aws_route_table.private.id
+}
+
+output "alb_dns_name" {
+  description = "ALB DNS 이름 — Spaceship에서 api.cluverse.cona.team CNAME 대상으로 입력"
+  value       = aws_lb.main.dns_name
+}
+
+output "alb_sg_id" {
+  description = "ALB 보안그룹 ID — test의 ecs_sg가 source SG로 참조"
+  value       = aws_security_group.alb.id
+}
+
+output "target_group_arn" {
+  description = "빈 Target Group ARN — test의 ECS 서비스가 여기에 등록"
+  value       = aws_lb_target_group.api.arn
+}
+
+output "acm_certificate_arn" {
+  description = "ACM 인증서 ARN"
+  value       = aws_acm_certificate.api.arn
+}
+
+# Spaceship DNS에 입력할 검증 레코드.
+# name에서 도메인 부분을 뺀 호스트 부분만 Spaceship의 Host 칸에 넣으면 된다.
+output "acm_validation_records" {
+  description = "Spaceship에 수동 입력할 ACM DNS 검증 CNAME 레코드"
+  value = [
+    for dvo in aws_acm_certificate.api.domain_validation_options : {
+      name  = dvo.resource_record_name
+      type  = dvo.resource_record_type
+      value = dvo.resource_record_value
+    }
+  ]
+}
+
+output "ecr_repository_url" {
+  description = "ECR 리포지토리 URL (docker push 대상)"
+  value       = aws_ecr_repository.api.repository_url
+}

--- a/terraform/base/security_groups.tf
+++ b/terraform/base/security_groups.tf
@@ -1,0 +1,39 @@
+# base에는 alb_sg만 둔다. 나머지 SG(ecs/db/redis/monitoring/bastion)는 test 스택에서 생성.
+# 순환 참조 방지를 위해 규칙은 aws_security_group_rule로 분리한다.
+resource "aws_security_group" "alb" {
+  name        = "cluverse-alb-sg"
+  description = "ALB: HTTP/HTTPS from anywhere"
+  vpc_id      = aws_vpc.main.id
+
+  tags = { Name = "cluverse-alb-sg" }
+}
+
+resource "aws_security_group_rule" "alb_in_http" {
+  type              = "ingress"
+  security_group_id = aws_security_group.alb.id
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "HTTP (redirect to HTTPS)"
+}
+
+resource "aws_security_group_rule" "alb_in_https" {
+  type              = "ingress"
+  security_group_id = aws_security_group.alb.id
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "HTTPS"
+}
+
+resource "aws_security_group_rule" "alb_out_all" {
+  type              = "egress"
+  security_group_id = aws_security_group.alb.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "ECS dynamic ports (32768-65535) to VPC targets"
+}

--- a/terraform/base/variables.tf
+++ b/terraform/base/variables.tf
@@ -1,0 +1,20 @@
+variable "aws_region" {
+  description = "AWS 리전"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "domain_name" {
+  description = "API 도메인 (Spaceship 등록, Route53 아님)"
+  type        = string
+  default     = "api.cluverse.cona.team"
+}
+
+# ACM 인증서는 Spaceship에 CNAME을 수동 입력해야 발급(ISSUED)된다.
+# 발급 전에는 ALB 443 리스너를 만들 수 없으므로(pending 인증서는 attach 불가),
+# 1차 apply(false) → Spaceship 검증 → 발급 확인 → -var certificate_validated=true 재-apply 순서로 진행한다.
+variable "certificate_validated" {
+  description = "ACM 인증서가 ISSUED 상태가 된 후 true로 바꿔 443 리스너를 생성"
+  type        = bool
+  default     = false
+}

--- a/terraform/base/versions.tf
+++ b/terraform/base/versions.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # state는 로컬 파일로 관리한다.
+  # test 스택이 ../base/terraform.tfstate 경로를 terraform_remote_state(local)로 읽으므로,
+  # S3 backend 등으로 이전할 경우 test/data.tf의 remote_state 설정도 함께 바꿔야 한다.
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = "cluverse"
+      ManagedBy = "terraform"
+      Stack     = "base"
+    }
+  }
+}

--- a/terraform/base/vpc.tf
+++ b/terraform/base/vpc.tf
@@ -1,0 +1,75 @@
+locals {
+  azs           = ["${var.aws_region}a", "${var.aws_region}c"]
+  public_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = { Name = "cluverse-vpc" }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = { Name = "cluverse-igw" }
+}
+
+resource "aws_subnet" "public" {
+  count = length(local.public_cidrs)
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = local.public_cidrs[count.index]
+  availability_zone       = local.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = { Name = "cluverse-public-${local.azs[count.index]}" }
+}
+
+resource "aws_subnet" "private" {
+  count = length(local.private_cidrs)
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = local.private_cidrs[count.index]
+  availability_zone = local.azs[count.index]
+
+  tags = { Name = "cluverse-private-${local.azs[count.index]}" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  tags = { Name = "cluverse-public-rt" }
+}
+
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.main.id
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(aws_subnet.public)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# 프라이빗 라우팅 테이블은 base에서 "빈 채로" 만든다.
+# egress(0.0.0.0/0 → NAT) route는 test 스택이 이 테이블 ID를 받아 추가한다.
+# NAT를 test에 두는 이유: apply/destroy 반복 시 NAT idle 비용을 없애기 위함.
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  tags = { Name = "cluverse-private-rt" }
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(aws_subnet.private)
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}

--- a/terraform/test/bastion.tf
+++ b/terraform/test/bastion.tf
@@ -1,0 +1,31 @@
+# Bastion (퍼블릭, EIP) — SSH는 var.my_ip에서만.
+# 로컬 Grafana/클라이언트 → SSH 터널 → 프라이빗 Prometheus(9090)/MySQL(3306)/Redis(6379).
+#
+# 권장 대안(SSM Session Manager): 22 오픈이나 공인 IP 없이도 포트포워딩이 가능하다.
+#   aws ssm start-session \
+#     --target <instance-id> \
+#     --document-name AWS-StartPortForwardingSessionToRemoteHost \
+#     --parameters '{"host":["10.0.11.30"],"portNumber":["9090"],"localPortNumber":["9090"]}'
+# 모든 인스턴스에 AmazonSSMManagedInstanceCore가 붙어 있어 그대로 사용 가능 (outputs.tf에도 예시).
+resource "aws_instance" "bastion" {
+  ami                         = data.aws_ssm_parameter.al2023_ami.value
+  instance_type               = "t3.micro"
+  subnet_id                   = local.public_subnet_ids[0]
+  associate_public_ip_address = true
+  vpc_security_group_ids      = [aws_security_group.bastion.id]
+  iam_instance_profile        = aws_iam_instance_profile.node.name
+  key_name                    = local.key_name
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  tags = { Name = "cluverse-bastion" }
+}
+
+resource "aws_eip" "bastion" {
+  instance = aws_instance.bastion.id
+  domain   = "vpc"
+
+  tags = { Name = "cluverse-bastion-eip" }
+}

--- a/terraform/test/data.tf
+++ b/terraform/test/data.tf
@@ -1,0 +1,40 @@
+# base 스택 output 참조 방식: terraform_remote_state (local backend).
+# base가 S3 backend로 이전하면 여기 backend/config만 맞춰 바꾸면 된다.
+data "terraform_remote_state" "base" {
+  backend = "local"
+
+  config = {
+    path = "${path.module}/../base/terraform.tfstate"
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+# 하드코딩 AMI 금지 — SSM 공개 파라미터로 최신 AMI 조회
+data "aws_ssm_parameter" "ecs_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
+}
+
+data "aws_ssm_parameter" "al2023_ami" {
+  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+}
+
+locals {
+  base = data.terraform_remote_state.base.outputs
+
+  vpc_id             = local.base.vpc_id
+  public_subnet_ids  = local.base.public_subnet_ids
+  private_subnet_ids = local.base.private_subnet_ids
+  alb_sg_id          = local.base.alb_sg_id
+  target_group_arn   = local.base.target_group_arn
+  ecr_repository_url = local.base.ecr_repository_url
+
+  key_name = var.ssh_public_key != "" ? aws_key_pair.main[0].key_name : null
+}
+
+resource "aws_key_pair" "main" {
+  count = var.ssh_public_key != "" ? 1 : 0
+
+  key_name   = "cluverse-test-key"
+  public_key = var.ssh_public_key
+}

--- a/terraform/test/ecs.tf
+++ b/terraform/test/ecs.tf
@@ -1,0 +1,173 @@
+locals {
+  cluster_name = "cluverse-test"
+}
+
+resource "aws_ecs_cluster" "main" {
+  name = local.cluster_name
+}
+
+resource "aws_cloudwatch_log_group" "api" {
+  name              = "/ecs/cluverse-api"
+  retention_in_days = 3 # 부하 테스트 용도라 짧게
+}
+
+resource "aws_launch_template" "ecs" {
+  name_prefix   = "cluverse-ecs-"
+  image_id      = data.aws_ssm_parameter.ecs_ami.value # ECS-optimized AL2023, SSM으로 최신 조회
+  instance_type = var.ecs_instance_type
+  key_name      = local.key_name
+
+  vpc_security_group_ids = [aws_security_group.ecs.id]
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.ecs_instance.arn
+  }
+
+  metadata_options {
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2 # 컨테이너에서 IMDS 접근(태스크 역할 등) 허용
+  }
+
+  user_data = base64encode(templatefile("${path.module}/templates/ecs_node.sh.tpl", {
+    cluster_name = local.cluster_name
+  }))
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name         = "cluverse-ecs-node"
+      Project      = "cluverse"
+      ManagedBy    = "terraform"
+      Stack        = "test"
+      NodeExporter = "true" # Prometheus ec2_sd가 이 태그로 node_exporter 대상 발견
+    }
+  }
+}
+
+resource "aws_autoscaling_group" "ecs" {
+  name                = "cluverse-ecs-asg"
+  min_size            = 0
+  max_size            = 4
+  desired_capacity    = var.ecs_desired_count
+  vpc_zone_identifier = local.private_subnet_ids
+
+  # 부팅 시 user_data가 인터넷에서 node_exporter를 받으므로 NAT route가 먼저 있어야 한다.
+  depends_on = [aws_route.private_nat]
+
+  launch_template {
+    id      = aws_launch_template.ecs.id
+    version = "$Latest"
+  }
+
+  # destroy를 빠르게 (부하 테스트 반복 사이클용)
+  force_delete = true
+
+  lifecycle {
+    ignore_changes = [desired_capacity] # capacity provider managed scaling이 조정
+  }
+
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = "true"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_ecs_capacity_provider" "main" {
+  name = "cluverse-test-cp"
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn = aws_autoscaling_group.ecs.arn
+    # ENABLED면 destroy 시 scale-in 보호가 걸려 오래 걸린다. 테스트용이라 DISABLED.
+    managed_termination_protection = "DISABLED"
+
+    managed_scaling {
+      status                    = "ENABLED"
+      target_capacity           = 100
+      minimum_scaling_step_size = 1
+      maximum_scaling_step_size = 2
+    }
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "main" {
+  cluster_name       = aws_ecs_cluster.main.name
+  capacity_providers = [aws_ecs_capacity_provider.main.name]
+
+  default_capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.main.name
+    weight            = 1
+  }
+}
+
+# 네트워크 모드: bridge + 동적 호스트 포트(hostPort=0).
+# base의 target group이 target_type="instance"로 만들어져 있으므로 반드시 bridge여야 한다.
+# (awsvpc로 바꾸려면 base의 target_type도 "ip"로 함께 바꿔야 함 — base/alb.tf 주석 참고)
+resource "aws_ecs_task_definition" "api" {
+  family                   = "cluverse-api"
+  requires_compatibilities = ["EC2"]
+  network_mode             = "bridge"
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name              = "cluverse-api"
+      image             = "${local.ecr_repository_url}:${var.container_image_tag}"
+      essential         = true
+      memoryReservation = 512
+      portMappings = [
+        { containerPort = 8080, hostPort = 0, protocol = "tcp" }
+      ]
+      environment = [
+        # Spring relaxed binding — docker-compose.yml과 동일한 관례로 주입
+        { name = "SPRING_DATASOURCE_URL", value = "jdbc:mysql://${var.mysql_private_ip}:3306/${var.db_name}?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true" },
+        { name = "SPRING_DATASOURCE_USERNAME", value = var.db_username },
+        { name = "SPRING_REDIS_HOST", value = var.redis_private_ip },
+        { name = "SPRING_REDIS_PORT", value = "6379" },
+        { name = "SPRING_DATA_REDIS_HOST", value = var.redis_private_ip },
+        { name = "SPRING_DATA_REDIS_PORT", value = "6379" }
+      ]
+      secrets = [
+        { name = "SPRING_DATASOURCE_PASSWORD", valueFrom = aws_ssm_parameter.db_password.arn }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.api.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "api"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "api" {
+  name            = "cluverse-api"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = var.ecs_desired_count
+
+  # Spring Boot 부팅이 느려 grace가 짧으면 ALB 헬스체크 실패 → 태스크 무한 재시작.
+  # 넉넉하게 180초.
+  health_check_grace_period_seconds = 180
+
+  capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.main.name
+    weight            = 1
+  }
+
+  load_balancer {
+    target_group_arn = local.target_group_arn # base의 빈 target group에 등록
+    container_name   = "cluverse-api"
+    container_port   = 8080
+  }
+
+  # DB/Redis가 준비된 뒤 태스크가 뜨도록 (부팅 직후 커넥션 실패로 인한 재시작 줄임)
+  depends_on = [
+    aws_ecs_cluster_capacity_providers.main,
+    aws_instance.mysql,
+    aws_instance.redis,
+  ]
+}

--- a/terraform/test/iam.tf
+++ b/terraform/test/iam.tf
@@ -1,0 +1,128 @@
+# ECS 관련 IAM 역할 3개는 용도가 다르므로 반드시 분리한다:
+#   (a) ecs_instance  — EC2(컨테이너 인스턴스) 자체의 역할. ECS agent 등록, ECR pull, SSM, CloudWatch agent.
+#   (b) task_execution — ECS가 태스크를 "띄울 때" 쓰는 역할. 이미지 pull, awslogs 로그 전송, SSM 파라미터(secrets) 읽기.
+#   (c) task           — 컨테이너 "안의 앱"이 AWS API를 부를 때 쓰는 역할. (현재 앱은 S3 등 미사용 → 빈 역할)
+
+data "aws_iam_policy_document" "ec2_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "ecs_tasks_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# ---------- (a) ECS 컨테이너 인스턴스 역할 ----------
+resource "aws_iam_role" "ecs_instance" {
+  name               = "cluverse-test-ecs-instance"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_ecs" {
+  role       = aws_iam_role.ecs_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_ssm" {
+  role       = aws_iam_role.ecs_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_cloudwatch" {
+  role       = aws_iam_role.ecs_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance" {
+  name = "cluverse-test-ecs-instance"
+  role = aws_iam_role.ecs_instance.name
+}
+
+# ---------- (b) Task Execution Role ----------
+resource "aws_iam_role" "task_execution" {
+  name               = "cluverse-test-task-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution_managed" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# 컨테이너 secrets(SSM Parameter Store) 읽기 권한
+resource "aws_iam_role_policy" "task_execution_ssm_params" {
+  name = "read-cluverse-ssm-params"
+  role = aws_iam_role.task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ssm:GetParameters"]
+      Resource = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/cluverse/test/*"
+    }]
+  })
+}
+
+# ---------- (c) Task Role (앱용, 현재 빈 역할) ----------
+resource "aws_iam_role" "task" {
+  name               = "cluverse-test-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
+}
+
+# ---------- 모니터링 EC2 역할 (Prometheus ec2_sd용 DescribeInstances + SSM) ----------
+resource "aws_iam_role" "monitoring" {
+  name               = "cluverse-test-monitoring"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "monitoring_ssm" {
+  role       = aws_iam_role.monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy" "monitoring_ec2_discovery" {
+  name = "prometheus-ec2-sd"
+  role = aws_iam_role.monitoring.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ec2:DescribeInstances", "ec2:DescribeAvailabilityZones"]
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "monitoring" {
+  name = "cluverse-test-monitoring"
+  role = aws_iam_role.monitoring.name
+}
+
+# ---------- 일반 노드(MySQL/Redis/Bastion) 공통 역할 — SSM 접근용 ----------
+resource "aws_iam_role" "node" {
+  name               = "cluverse-test-node"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "node_ssm" {
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "node" {
+  name = "cluverse-test-node"
+  role = aws_iam_role.node.name
+}

--- a/terraform/test/monitoring.tf
+++ b/terraform/test/monitoring.tf
@@ -1,0 +1,34 @@
+# Prometheus/Grafana EC2 (프라이빗) — docker compose로 구동.
+# 접근은 bastion 터널(9090/3000) 또는 SSM 포트포워딩으로만 한다 (outputs.tf 참고).
+resource "aws_instance" "monitoring" {
+  ami                    = data.aws_ssm_parameter.al2023_ami.value
+  instance_type          = var.monitoring_instance_type
+  subnet_id              = local.private_subnet_ids[0]
+  private_ip             = var.monitoring_private_ip
+  vpc_security_group_ids = [aws_security_group.monitoring.id]
+  iam_instance_profile   = aws_iam_instance_profile.monitoring.name
+  key_name               = local.key_name
+
+  depends_on = [aws_route.private_nat]
+
+  metadata_options {
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2 # 컨테이너(Prometheus ec2_sd)의 IMDS 자격증명 접근용
+  }
+
+  root_block_device {
+    volume_size = 20
+    volume_type = "gp3"
+  }
+
+  user_data = templatefile("${path.module}/templates/monitoring.sh.tpl", {
+    aws_region = var.aws_region
+    mysql_ip   = var.mysql_private_ip
+    redis_ip   = var.redis_private_ip
+  })
+
+  tags = {
+    Name         = "cluverse-monitoring"
+    NodeExporter = "true"
+  }
+}

--- a/terraform/test/mysql.tf
+++ b/terraform/test/mysql.tf
@@ -1,0 +1,36 @@
+# MySQL 전용 EC2 (프라이빗, 고정 사설 IP).
+# EC2 직접 설치라 destroy 시 데이터가 휘발되지만, 부하 테스트에선 매번 클린 상태가 오히려 유리.
+resource "aws_instance" "mysql" {
+  ami                    = data.aws_ssm_parameter.al2023_ami.value
+  instance_type          = var.db_instance_type
+  subnet_id              = local.private_subnet_ids[0]
+  private_ip             = var.mysql_private_ip
+  vpc_security_group_ids = [aws_security_group.db.id]
+  iam_instance_profile   = aws_iam_instance_profile.node.name
+  key_name               = local.key_name
+
+  # user_data가 MySQL yum repo/exporter를 인터넷에서 받으므로 NAT route 선행 필요
+  depends_on = [aws_route.private_nat]
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 30
+    volume_type = "gp3"
+  }
+
+  # 비밀번호는 user_data에 평문으로 싣지 않고, 부팅 시 SSM Parameter Store에서 조회한다
+  user_data = templatefile("${path.module}/templates/mysql.sh.tpl", {
+    db_name             = var.db_name
+    db_username         = var.db_username
+    db_password_ssm_key = aws_ssm_parameter.db_password.name
+    aws_region          = var.aws_region
+  })
+
+  tags = {
+    Name         = "cluverse-mysql"
+    NodeExporter = "true"
+  }
+}

--- a/terraform/test/nat.tf
+++ b/terraform/test/nat.tf
@@ -1,0 +1,28 @@
+# NAT Gateway를 test에 두는 이유:
+#   프라이빗 인스턴스들이 user_data로 MySQL/Redis/Docker/exporter를 인터넷에서 설치하므로
+#   egress가 필요하다. NAT를 test에 두면 destroy 시 함께 사라져 idle 비용(시간당 요금)이 없다.
+#
+# 대안(트레이드오프): 모든 소프트웨어를 미리 구워 둔 커스텀 AMI(Packer 등)를 쓰면
+#   NAT 없이도 프라이빗 인스턴스를 띄울 수 있다. 반복 테스트가 잦으면 부팅이 수 분 → 수십 초로
+#   줄고 NAT 요금도 없어 더 빠르고 싸다. 대신 AMI 빌드 파이프라인 유지 비용이 생긴다.
+#   지금은 "백지 계정에서 바로 실행 가능"을 우선해 NAT + user_data 설치를 택했다.
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = { Name = "cluverse-nat-eip" }
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = local.public_subnet_ids[0] # 단일 NAT (테스트 용도, AZ 이중화 불필요)
+
+  tags = { Name = "cluverse-nat" }
+}
+
+# base가 빈 채로 만들어 둔 프라이빗 라우팅 테이블에 egress route를 추가한다.
+# test destroy 시 이 route와 NAT가 함께 사라지고, 라우팅 테이블 자체는 base에 남는다.
+resource "aws_route" "private_nat" {
+  route_table_id         = local.base.private_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.main.id
+}

--- a/terraform/test/outputs.tf
+++ b/terraform/test/outputs.tf
@@ -1,0 +1,55 @@
+output "bastion_public_ip" {
+  description = "Bastion EIP"
+  value       = aws_eip.bastion.public_ip
+}
+
+output "nat_public_ip" {
+  description = "NAT Gateway 공인 IP"
+  value       = aws_eip.nat.public_ip
+}
+
+output "mysql_private_ip" {
+  description = "MySQL 고정 사설 IP"
+  value       = aws_instance.mysql.private_ip
+}
+
+output "redis_private_ip" {
+  description = "Redis 고정 사설 IP"
+  value       = aws_instance.redis.private_ip
+}
+
+output "monitoring_private_ip" {
+  description = "Prometheus/Grafana 사설 IP"
+  value       = aws_instance.monitoring.private_ip
+}
+
+output "ecs_cluster_name" {
+  description = "ECS 클러스터 이름"
+  value       = aws_ecs_cluster.main.name
+}
+
+# 로컬 → bastion → 프라이빗 리소스 SSH 터널.
+# 로컬에서 실행 후: Grafana http://localhost:3000, Prometheus http://localhost:9090,
+# MySQL localhost:3306, Redis localhost:6379 로 접근.
+output "ssh_tunnel_command" {
+  description = "Grafana/Prometheus/MySQL/Redis 터널 명령 (ssh_public_key를 넣었을 때)"
+  value = join(" ", [
+    "ssh -N",
+    "-L 3000:${aws_instance.monitoring.private_ip}:3000",
+    "-L 9090:${aws_instance.monitoring.private_ip}:9090",
+    "-L 3306:${aws_instance.mysql.private_ip}:3306",
+    "-L 6379:${aws_instance.redis.private_ip}:6379",
+    "ec2-user@${aws_eip.bastion.public_ip}",
+  ])
+}
+
+# SSM Session Manager 대안 — SSH 키/22 포트 없이 포트포워딩 (bastion 경유 불필요)
+output "ssm_port_forward_examples" {
+  description = "SSM 포트포워딩 예시 (인스턴스에 직접 연결)"
+  value = {
+    grafana    = "aws ssm start-session --target ${aws_instance.monitoring.id} --document-name AWS-StartPortForwardingSession --parameters '{\"portNumber\":[\"3000\"],\"localPortNumber\":[\"3000\"]}'"
+    prometheus = "aws ssm start-session --target ${aws_instance.monitoring.id} --document-name AWS-StartPortForwardingSession --parameters '{\"portNumber\":[\"9090\"],\"localPortNumber\":[\"9090\"]}'"
+    mysql      = "aws ssm start-session --target ${aws_instance.bastion.id} --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{\"host\":[\"${aws_instance.mysql.private_ip}\"],\"portNumber\":[\"3306\"],\"localPortNumber\":[\"3306\"]}'"
+    redis      = "aws ssm start-session --target ${aws_instance.bastion.id} --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{\"host\":[\"${aws_instance.redis.private_ip}\"],\"portNumber\":[\"6379\"],\"localPortNumber\":[\"6379\"]}'"
+  }
+}

--- a/terraform/test/redis.tf
+++ b/terraform/test/redis.tf
@@ -1,0 +1,24 @@
+# Redis 전용 EC2 — MySQL과 별도 인스턴스로 분리.
+# 부하 시 DB와 캐시의 자원(CPU/메모리/네트워크) 경합을 분리해 측정하기 위함.
+resource "aws_instance" "redis" {
+  ami                    = data.aws_ssm_parameter.al2023_ami.value
+  instance_type          = var.redis_instance_type
+  subnet_id              = local.private_subnet_ids[0]
+  private_ip             = var.redis_private_ip
+  vpc_security_group_ids = [aws_security_group.redis.id]
+  iam_instance_profile   = aws_iam_instance_profile.node.name
+  key_name               = local.key_name
+
+  depends_on = [aws_route.private_nat]
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  user_data = templatefile("${path.module}/templates/redis.sh.tpl", {})
+
+  tags = {
+    Name         = "cluverse-redis"
+    NodeExporter = "true"
+  }
+}

--- a/terraform/test/security_groups.tf
+++ b/terraform/test/security_groups.tf
@@ -1,0 +1,282 @@
+# 계단식 SG — 모든 인바운드는 source SG 참조(공인 IP 예외는 bastion의 my_ip 뿐).
+# 상호 참조로 인한 순환을 피하기 위해 SG 본체와 규칙(aws_security_group_rule)을 분리한다.
+
+resource "aws_security_group" "ecs" {
+  name        = "cluverse-ecs-sg"
+  description = "ECS container instances"
+  vpc_id      = local.vpc_id
+
+  tags = { Name = "cluverse-ecs-sg" }
+}
+
+resource "aws_security_group" "db" {
+  name        = "cluverse-db-sg"
+  description = "MySQL EC2"
+  vpc_id      = local.vpc_id
+
+  tags = { Name = "cluverse-db-sg" }
+}
+
+resource "aws_security_group" "redis" {
+  name        = "cluverse-redis-sg"
+  description = "Redis EC2"
+  vpc_id      = local.vpc_id
+
+  tags = { Name = "cluverse-redis-sg" }
+}
+
+resource "aws_security_group" "monitoring" {
+  name        = "cluverse-monitoring-sg"
+  description = "Prometheus/Grafana EC2"
+  vpc_id      = local.vpc_id
+
+  tags = { Name = "cluverse-monitoring-sg" }
+}
+
+resource "aws_security_group" "bastion" {
+  name        = "cluverse-bastion-sg"
+  description = "Bastion host"
+  vpc_id      = local.vpc_id
+
+  tags = { Name = "cluverse-bastion-sg" }
+}
+
+# ---------- ecs_sg ----------
+# bridge + 동적 포트(32768-65535)이므로 ALB에서 동적 포트 범위를 연다.
+resource "aws_security_group_rule" "ecs_in_alb_dynamic" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.ecs.id
+  from_port                = 32768
+  to_port                  = 65535
+  protocol                 = "tcp"
+  source_security_group_id = local.alb_sg_id
+  description              = "ALB to ECS dynamic host ports"
+}
+
+resource "aws_security_group_rule" "ecs_in_monitoring_node_exporter" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.ecs.id
+  from_port                = 9100
+  to_port                  = 9100
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.monitoring.id
+  description              = "Prometheus scrape node_exporter"
+}
+
+# 앱 컨테이너의 /actuator/prometheus 도 동적 호스트 포트에 물리므로 범위로 연다.
+resource "aws_security_group_rule" "ecs_in_monitoring_app" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.ecs.id
+  from_port                = 32768
+  to_port                  = 65535
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.monitoring.id
+  description              = "Prometheus scrape app dynamic ports"
+}
+
+resource "aws_security_group_rule" "ecs_out_all" {
+  type              = "egress"
+  security_group_id = aws_security_group.ecs.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "ECR pull, package install via NAT, DB/Redis access"
+}
+
+# ---------- db_sg ----------
+resource "aws_security_group_rule" "db_in_ecs_mysql" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.db.id
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs.id
+  description              = "MySQL from ECS"
+}
+
+# 로컬 → bastion 터널 → MySQL(3306) 접근 경로. 터널의 소스는 bastion이므로 필요.
+resource "aws_security_group_rule" "db_in_bastion_mysql" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.db.id
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+  description              = "MySQL via bastion tunnel"
+}
+
+resource "aws_security_group_rule" "db_in_monitoring_mysqld_exporter" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.db.id
+  from_port                = 9104
+  to_port                  = 9104
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.monitoring.id
+  description              = "Prometheus scrape mysqld_exporter"
+}
+
+resource "aws_security_group_rule" "db_in_monitoring_node_exporter" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.db.id
+  from_port                = 9100
+  to_port                  = 9100
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.monitoring.id
+  description              = "Prometheus scrape node_exporter"
+}
+
+resource "aws_security_group_rule" "db_in_bastion_ssh" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.db.id
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+  description              = "SSH from bastion"
+}
+
+resource "aws_security_group_rule" "db_out_all" {
+  type              = "egress"
+  security_group_id = aws_security_group.db.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "package install via NAT"
+}
+
+# ---------- redis_sg ----------
+resource "aws_security_group_rule" "redis_in_ecs" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.redis.id
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs.id
+  description              = "Redis from ECS"
+}
+
+resource "aws_security_group_rule" "redis_in_bastion" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.redis.id
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+  description              = "Redis via bastion tunnel"
+}
+
+resource "aws_security_group_rule" "redis_in_monitoring_redis_exporter" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.redis.id
+  from_port                = 9121
+  to_port                  = 9121
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.monitoring.id
+  description              = "Prometheus scrape redis_exporter"
+}
+
+resource "aws_security_group_rule" "redis_in_monitoring_node_exporter" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.redis.id
+  from_port                = 9100
+  to_port                  = 9100
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.monitoring.id
+  description              = "Prometheus scrape node_exporter"
+}
+
+resource "aws_security_group_rule" "redis_in_bastion_ssh" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.redis.id
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+  description              = "SSH from bastion"
+}
+
+resource "aws_security_group_rule" "redis_out_all" {
+  type              = "egress"
+  security_group_id = aws_security_group.redis.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "package install via NAT"
+}
+
+# ---------- monitoring_sg ----------
+# 9090(Prometheus)/3000(Grafana)은 bastion 터널로만. 전세계 오픈 금지.
+resource "aws_security_group_rule" "monitoring_in_bastion_prometheus" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.monitoring.id
+  from_port                = 9090
+  to_port                  = 9090
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+  description              = "Prometheus UI via bastion tunnel"
+}
+
+resource "aws_security_group_rule" "monitoring_in_bastion_grafana" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.monitoring.id
+  from_port                = 3000
+  to_port                  = 3000
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+  description              = "Grafana via bastion tunnel"
+}
+
+resource "aws_security_group_rule" "monitoring_in_bastion_ssh" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.monitoring.id
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+  description              = "SSH from bastion"
+}
+
+# Prometheus(host 네트워크 컨테이너)가 자기 호스트의 node_exporter를 사설 IP로 self-scrape
+resource "aws_security_group_rule" "monitoring_in_self_node_exporter" {
+  type              = "ingress"
+  security_group_id = aws_security_group.monitoring.id
+  from_port         = 9100
+  to_port           = 9100
+  protocol          = "tcp"
+  self              = true
+  description       = "Prometheus self-scrape node_exporter"
+}
+
+resource "aws_security_group_rule" "monitoring_out_all" {
+  type              = "egress"
+  security_group_id = aws_security_group.monitoring.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "docker pull via NAT, scrape targets"
+}
+
+# ---------- bastion_sg ----------
+resource "aws_security_group_rule" "bastion_in_ssh" {
+  type              = "ingress"
+  security_group_id = aws_security_group.bastion.id
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [var.my_ip]
+  description       = "SSH from my_ip only"
+}
+
+resource "aws_security_group_rule" "bastion_out_all" {
+  type              = "egress"
+  security_group_id = aws_security_group.bastion.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "tunnel targets"
+}

--- a/terraform/test/ssm.tf
+++ b/terraform/test/ssm.tf
@@ -1,0 +1,9 @@
+# DB 자격증명은 SSM Parameter Store에 두고 ECS 태스크가 secrets로 참조한다.
+# (태스크 정의 JSON에 평문 비밀번호가 남지 않음)
+resource "aws_ssm_parameter" "db_password" {
+  name  = "/cluverse/test/db/password"
+  type  = "SecureString"
+  value = var.db_password
+
+  tags = { Name = "cluverse-db-password" }
+}

--- a/terraform/test/templates/ecs_node.sh.tpl
+++ b/terraform/test/templates/ecs_node.sh.tpl
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euxo pipefail
+exec > /var/log/user-data.log 2>&1
+
+# ECS agent를 클러스터에 등록
+cat >> /etc/ecs/ecs.config <<EOF
+ECS_CLUSTER=${cluster_name}
+EOF
+
+# node_exporter — 호스트 CPU steal / T계열 크레딧 소진을 앱 병목과 분리 관측
+NE_VERSION=1.8.2
+curl -fsSL -o /tmp/node_exporter.tar.gz "https://github.com/prometheus/node_exporter/releases/download/v$NE_VERSION/node_exporter-$NE_VERSION.linux-amd64.tar.gz"
+tar -xzf /tmp/node_exporter.tar.gz -C /tmp
+install -m 755 "/tmp/node_exporter-$NE_VERSION.linux-amd64/node_exporter" /usr/local/bin/node_exporter
+
+cat > /etc/systemd/system/node_exporter.service <<'EOF'
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+User=nobody
+ExecStart=/usr/local/bin/node_exporter --web.listen-address=:9100
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now node_exporter

--- a/terraform/test/templates/monitoring.sh.tpl
+++ b/terraform/test/templates/monitoring.sh.tpl
@@ -1,0 +1,110 @@
+#!/bin/bash
+set -euxo pipefail
+exec > /var/log/user-data.log 2>&1
+
+# ---------- Docker + compose plugin ----------
+dnf -y install docker
+systemctl enable --now docker
+mkdir -p /usr/local/lib/docker/cli-plugins
+curl -fsSL -o /usr/local/lib/docker/cli-plugins/docker-compose \
+  "https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-linux-x86_64"
+chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+mkdir -p /opt/monitoring/grafana/provisioning/datasources
+
+# ---------- Prometheus 설정 ----------
+# - mysqld/redis exporter는 고정 IP로 static scrape
+# - node_exporter는 EC2 SD(tag:NodeExporter=true)로 자동 발견 (ECS ASG 노드 포함)
+# - 앱(/actuator/prometheus)은 bridge+동적 호스트 포트라 static 설정이 불가.
+#   앱 레벨 메트릭까지 보려면 (1) hostPort를 8080 고정(인스턴스당 1태스크로 제한)하거나
+#   (2) ECS 태스크 디스커버리(prometheus-ecs-discovery 등)를 붙일 것. 지금은 exporter 중심 구성.
+cat > /opt/monitoring/prometheus.yml <<'EOF'
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: mysqld
+    static_configs:
+      - targets: ["${mysql_ip}:9104"]
+
+  - job_name: redis
+    static_configs:
+      - targets: ["${redis_ip}:9121"]
+
+  - job_name: node
+    ec2_sd_configs:
+      - region: ${aws_region}
+        port: 9100
+        filters:
+          - name: tag:NodeExporter
+            values: ["true"]
+          - name: instance-state-name
+            values: ["running"]
+    relabel_configs:
+      - source_labels: [__meta_ec2_tag_Name]
+        target_label: instance_name
+EOF
+
+# ---------- Grafana 데이터소스 자동 등록 ----------
+cat > /opt/monitoring/grafana/provisioning/datasources/prometheus.yml <<'EOF'
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://localhost:9090
+    isDefault: true
+EOF
+
+# ---------- docker compose ----------
+# host 네트워크: ec2_sd가 인스턴스 프로파일(IMDS) 자격증명을 그대로 쓰고, 포트 매핑도 단순해진다.
+cat > /opt/monitoring/docker-compose.yml <<'EOF'
+services:
+  prometheus:
+    image: prom/prometheus:v2.53.0
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+      - /opt/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prom_data:/prometheus
+
+  grafana:
+    image: grafana/grafana:11.1.0
+    network_mode: host
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin # bastion 터널로만 접근 가능하므로 기본값 유지
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - /opt/monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+
+volumes:
+  prom_data:
+  grafana_data:
+EOF
+
+docker compose -f /opt/monitoring/docker-compose.yml up -d
+
+# ---------- node_exporter (9100, 모니터링 호스트 자신) ----------
+NE_VERSION=1.8.2
+curl -fsSL -o /tmp/node_exporter.tar.gz "https://github.com/prometheus/node_exporter/releases/download/v$NE_VERSION/node_exporter-$NE_VERSION.linux-amd64.tar.gz"
+tar -xzf /tmp/node_exporter.tar.gz -C /tmp
+install -m 755 "/tmp/node_exporter-$NE_VERSION.linux-amd64/node_exporter" /usr/local/bin/node_exporter
+
+cat > /etc/systemd/system/node_exporter.service <<'EOF'
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+User=nobody
+ExecStart=/usr/local/bin/node_exporter --web.listen-address=:9100
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now node_exporter

--- a/terraform/test/templates/mysql.sh.tpl
+++ b/terraform/test/templates/mysql.sh.tpl
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -euxo pipefail
+exec > /var/log/user-data.log 2>&1
+
+# ---------- MySQL 8.0 설치 (AL2023 = EL9 호환, MySQL 공식 repo) ----------
+rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2023
+dnf -y install https://repo.mysql.com/mysql80-community-release-el9.rpm
+dnf -y install mysql-community-server
+
+# RDS Performance Insights를 수동 재현하기 위한 설정:
+#   slow_query_log + 낮은 long_query_time, performance_schema ON
+# loose- 접두사: validate_password 컴포넌트 미로드 시에도 기동 실패하지 않도록
+cat > /etc/my.cnf.d/zz-cluverse.cnf <<'EOF'
+[mysqld]
+bind-address = 0.0.0.0
+slow_query_log = 1
+slow_query_log_file = /var/lib/mysql/slow.log
+long_query_time = 0.2
+log_slow_admin_statements = 1
+performance_schema = ON
+loose-validate_password.policy = LOW
+EOF
+
+systemctl enable --now mysqld
+
+# 기동 대기
+for i in $(seq 1 60); do
+  mysqladmin ping --silent && break
+  sleep 2
+done
+
+# 비밀번호는 SSM Parameter Store에서 조회 (user_data 평문 노출 방지).
+# node 롤의 AmazonSSMManagedInstanceCore에 ssm:GetParameter 포함.
+# set +x: 비밀번호가 /var/log/user-data.log에 트레이스로 남지 않도록 이 구간은 제외
+set +x
+DB_PASSWORD=""
+for i in $(seq 1 12); do
+  DB_PASSWORD=$(aws ssm get-parameter \
+    --region ${aws_region} \
+    --name '${db_password_ssm_key}' \
+    --with-decryption \
+    --query Parameter.Value \
+    --output text) && break
+  echo "SSM 비밀번호 조회 재시도 ($i/12)"
+  sleep 5
+done
+test -n "$DB_PASSWORD" || { echo "SSM 비밀번호 조회 실패"; exit 1; }
+
+# RPM 설치 시 root 임시 비밀번호가 로그에 남는다
+TMP_PW=$(grep 'temporary password' /var/log/mysqld.log | tail -1 | awk '{print $NF}')
+
+# 앱 DB/유저 + exporter 전용 제한 계정 생성
+# (비밀번호는 변수 validation으로 영숫자만 허용 → SQL/cnf 이스케이프 불필요)
+mysql --connect-expired-password -uroot -p"$TMP_PW" <<SQL
+ALTER USER 'root'@'localhost' IDENTIFIED BY '$DB_PASSWORD';
+CREATE DATABASE IF NOT EXISTS ${db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER IF NOT EXISTS '${db_username}'@'%' IDENTIFIED BY '$DB_PASSWORD';
+GRANT ALL PRIVILEGES ON ${db_name}.* TO '${db_username}'@'%';
+CREATE USER IF NOT EXISTS 'exporter'@'localhost' IDENTIFIED BY '$DB_PASSWORD' WITH MAX_USER_CONNECTIONS 3;
+GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'localhost';
+FLUSH PRIVILEGES;
+SQL
+
+# exporter 접속 정보도 같은 비-트레이스 구간에서 기록
+cat > /etc/mysqld_exporter.cnf <<EOF
+[client]
+user = exporter
+password = "$DB_PASSWORD"
+EOF
+chmod 600 /etc/mysqld_exporter.cnf
+set -x
+
+# ---------- mysqld_exporter (9104, 제한 권한 exporter 계정 사용) ----------
+ME_VERSION=0.15.1
+curl -fsSL -o /tmp/mysqld_exporter.tar.gz "https://github.com/prometheus/mysqld_exporter/releases/download/v$ME_VERSION/mysqld_exporter-$ME_VERSION.linux-amd64.tar.gz"
+tar -xzf /tmp/mysqld_exporter.tar.gz -C /tmp
+install -m 755 "/tmp/mysqld_exporter-$ME_VERSION.linux-amd64/mysqld_exporter" /usr/local/bin/mysqld_exporter
+
+cat > /etc/systemd/system/mysqld_exporter.service <<'EOF'
+[Unit]
+Description=Prometheus MySQL Exporter
+After=mysqld.service
+
+[Service]
+ExecStart=/usr/local/bin/mysqld_exporter --config.my-cnf=/etc/mysqld_exporter.cnf --web.listen-address=:9104
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# ---------- node_exporter (9100) ----------
+NE_VERSION=1.8.2
+curl -fsSL -o /tmp/node_exporter.tar.gz "https://github.com/prometheus/node_exporter/releases/download/v$NE_VERSION/node_exporter-$NE_VERSION.linux-amd64.tar.gz"
+tar -xzf /tmp/node_exporter.tar.gz -C /tmp
+install -m 755 "/tmp/node_exporter-$NE_VERSION.linux-amd64/node_exporter" /usr/local/bin/node_exporter
+
+cat > /etc/systemd/system/node_exporter.service <<'EOF'
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+User=nobody
+ExecStart=/usr/local/bin/node_exporter --web.listen-address=:9100
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now mysqld_exporter node_exporter

--- a/terraform/test/templates/redis.sh.tpl
+++ b/terraform/test/templates/redis.sh.tpl
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euxo pipefail
+exec > /var/log/user-data.log 2>&1
+
+# ---------- Redis 설치 (AL2023 기본 저장소의 redis6) ----------
+dnf -y install redis6
+
+# SG(redis_sg)로 접근을 제한하므로 인증 없이 VPC 내부 접근 허용.
+sed -i 's/^bind .*/bind 0.0.0.0/' /etc/redis6/redis6.conf
+sed -i 's/^protected-mode .*/protected-mode no/' /etc/redis6/redis6.conf
+
+systemctl enable --now redis6
+
+# ---------- redis_exporter (9121) ----------
+RE_VERSION=1.62.0
+curl -fsSL -o /tmp/redis_exporter.tar.gz "https://github.com/oliver006/redis_exporter/releases/download/v$RE_VERSION/redis_exporter-v$RE_VERSION.linux-amd64.tar.gz"
+tar -xzf /tmp/redis_exporter.tar.gz -C /tmp
+install -m 755 "/tmp/redis_exporter-v$RE_VERSION.linux-amd64/redis_exporter" /usr/local/bin/redis_exporter
+
+cat > /etc/systemd/system/redis_exporter.service <<'EOF'
+[Unit]
+Description=Prometheus Redis Exporter
+After=redis6.service
+
+[Service]
+User=nobody
+ExecStart=/usr/local/bin/redis_exporter --redis.addr=redis://localhost:6379
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# ---------- node_exporter (9100) ----------
+NE_VERSION=1.8.2
+curl -fsSL -o /tmp/node_exporter.tar.gz "https://github.com/prometheus/node_exporter/releases/download/v$NE_VERSION/node_exporter-$NE_VERSION.linux-amd64.tar.gz"
+tar -xzf /tmp/node_exporter.tar.gz -C /tmp
+install -m 755 "/tmp/node_exporter-$NE_VERSION.linux-amd64/node_exporter" /usr/local/bin/node_exporter
+
+cat > /etc/systemd/system/node_exporter.service <<'EOF'
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+User=nobody
+ExecStart=/usr/local/bin/node_exporter --web.listen-address=:9100
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now redis_exporter node_exporter

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -1,0 +1,106 @@
+variable "aws_region" {
+  description = "AWS 리전"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "my_ip" {
+  description = "Bastion SSH를 허용할 내 공인 IP (CIDR, 예: 1.2.3.4/32)"
+  type        = string
+
+  validation {
+    condition     = can(cidrnetmask(var.my_ip))
+    error_message = "my_ip는 CIDR 표기여야 합니다 (예: 1.2.3.4/32)."
+  }
+}
+
+variable "db_password" {
+  description = "MySQL 비밀번호 (root/앱유저/exporter 공용). MySQL validate_password 정책은 LOW로 낮춰두지만 8자 이상 권장."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.db_password) >= 8
+    error_message = "db_password는 8자 이상이어야 합니다."
+  }
+
+  # user_data 스크립트가 비밀번호를 SQL 리터럴/my.cnf에 그대로 넣으므로,
+  # 이스케이프 처리 대신 영숫자로 제한한다 (테스트 스택 전용 비밀번호)
+  validation {
+    condition     = can(regex("^[A-Za-z0-9]+$", var.db_password))
+    error_message = "db_password는 영문자와 숫자만 사용할 수 있습니다."
+  }
+}
+
+variable "db_name" {
+  description = "애플리케이션 DB 이름"
+  type        = string
+  default     = "cluverse_v2" # src/main/resources/application.yml 의 DB 이름과 일치
+}
+
+variable "db_username" {
+  description = "애플리케이션 DB 사용자"
+  type        = string
+  default     = "cluverse_user"
+}
+
+variable "ecs_desired_count" {
+  description = "ECS 서비스 desired task 수"
+  type        = number
+  default     = 1
+}
+
+variable "ecs_instance_type" {
+  description = "ECS 컨테이너 인스턴스 타입"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "db_instance_type" {
+  description = "MySQL EC2 인스턴스 타입"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "redis_instance_type" {
+  description = "Redis EC2 인스턴스 타입"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "monitoring_instance_type" {
+  description = "Prometheus/Grafana EC2 인스턴스 타입"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "container_image_tag" {
+  description = "ECR cluverse-api 이미지 태그"
+  type        = string
+  default     = "latest"
+}
+
+variable "ssh_public_key" {
+  description = "인스턴스에 심을 SSH 공개키. 빈 문자열이면 키페어 없이 생성(SSM 접근만 가능)."
+  type        = string
+  default     = ""
+}
+
+# 고정 사설 IP — base의 첫 번째 프라이빗 서브넷(10.0.11.0/24) 대역 안이어야 한다.
+variable "mysql_private_ip" {
+  description = "MySQL EC2 고정 사설 IP"
+  type        = string
+  default     = "10.0.11.10"
+}
+
+variable "redis_private_ip" {
+  description = "Redis EC2 고정 사설 IP"
+  type        = string
+  default     = "10.0.11.20"
+}
+
+variable "monitoring_private_ip" {
+  description = "Prometheus/Grafana EC2 고정 사설 IP"
+  type        = string
+  default     = "10.0.11.30"
+}

--- a/terraform/test/versions.tf
+++ b/terraform/test/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = "cluverse"
+      ManagedBy = "terraform"
+      Stack     = "test"
+    }
+  }
+}


### PR DESCRIPTION
## 개요

부하 테스트를 위해 AWS 인프라를 Terraform으로 신규 구성합니다. `apply`/`destroy`를 반복해도 DNS·HTTPS(ALB DNS 이름, ACM 검증)가 리셋되지 않도록 state를 **base / test 두 스택으로 분리**했습니다.

## 구성

### `terraform/base` — 1회 apply, destroy 안 함
- VPC `10.0.0.0/16`, 퍼블릭 2 + 프라이빗 2 서브넷 (2 AZ), IGW, 퍼블릭 라우팅
- 프라이빗 라우팅 테이블은 **빈 채로** 생성 → route table ID를 output으로 test에 전달
- ALB(퍼블릭) + 80(→443 리다이렉트)/443 리스너, 빈 Target Group(`/actuator/health`, matcher 200)
- ACM 인증서(`api.cluverse.cona.team`) — Route53이 아니므로 `aws_acm_certificate_validation` 미사용, 검증 CNAME을 output으로 출력해 Spaceship 수동 입력
- `alb_sg`, ECR 리포지토리(`cluverse-api`)

### `terraform/test` — apply/destroy 반복
- base output을 `terraform_remote_state`(local, `../base/terraform.tfstate`)로 참조
- 단일 NAT Gateway + base 프라이빗 RT에 egress route 추가 (destroy 시 NAT 소멸 → idle 비용 0)
- ECS on EC2: 클러스터 + Launch Template(SSM 조회 AMI) + ASG + Capacity Provider, **bridge + 동적 포트**(base TG `target_type=instance`와 합의), grace period 180초, node_exporter 동반
- MySQL 8.0 EC2(slow log·performance_schema·mysqld_exporter), Redis EC2(redis_exporter), Prometheus/Grafana EC2(docker compose, EC2 SD), 고정 사설 IP
- Bastion(EIP, `my_ip`만 22 허용) + SSH 터널/SSM 포트포워딩 명령 output
- 계단식 SG 5종(source SG 참조, `aws_security_group_rule` 분리), IAM 역할 분리(인스턴스/task execution/task), DB 비밀번호 SSM SecureString → ECS secrets

## 실행 순서

`terraform/README.md` 체크리스트 참고: base apply → Spaceship에 ACM 검증 레코드 입력 → 발급 확인 후 `-var certificate_validated=true` 재-apply → CNAME → ECR push → test apply → 터널로 Grafana 연결. 이후 test만 반복.

## 검증

- [x] `terraform init` / `terraform validate` 통과 (base, test)
- [x] `terraform fmt -recursive` 적용
- [x] user_data 템플릿 4종 `templatefile` 렌더링 + 렌더링 결과 `bash -n` 문법 검증 통과
- [ ] 실제 apply는 AWS 자격증명 필요 (README 순서대로 수동 진행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 부하 테스트 환경을 위한 AWS 인프라 구성을 추가했습니다.
  * HTTPS 기반 API 접근과 도메인 인증서 발급 절차를 지원합니다.
  * ECS 기반 API 실행, 자동 확장, 로그 수집 환경을 제공합니다.
  * MySQL·Redis 및 Prometheus·Grafana 모니터링 환경을 구성할 수 있습니다.
  * 배스천 호스트와 SSH/SSM 포트 포워딩을 통한 내부 서비스 접근을 지원합니다.

* **문서**
  * 기본 환경과 테스트 환경을 분리한 구축·운영 가이드를 추가했습니다.
  * 반복적인 테스트 환경 생성 및 삭제 절차와 필수 설정을 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->